### PR TITLE
Add support for the same unique suffix to used in all resource naming

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -1,8 +1,8 @@
 // Global parameters
 targetScope = 'subscription'
 
-@description('GUID for Resource Naming')
-param guid string = newGuid()
+@description('Unique String for Resource Naming')
+param uniqueSuffix string
 
 @description('Deployment Location')
 param location string = deployment().location
@@ -35,18 +35,18 @@ param tags object = {}
 
 @description('IPAM Resource Names')
 param resourceNames object = {
-  functionName: '${namePrefix}-${uniqueString(guid)}'
-  appServiceName: '${namePrefix}-${uniqueString(guid)}'
-  appServicePlanName: '${namePrefix}-asp-${uniqueString(guid)}'
-  cosmosAccountName: '${namePrefix}-dbacct-${uniqueString(guid)}'
+  functionName: '${namePrefix}-${uniqueSuffix}'
+  appServiceName: '${namePrefix}-${uniqueSuffix}'
+  appServicePlanName: '${namePrefix}-asp-${uniqueSuffix}'
+  cosmosAccountName: '${namePrefix}-dbacct-${uniqueSuffix}'
   cosmosContainerName: '${namePrefix}-ctr'
   cosmosDatabaseName: '${namePrefix}-db'
-  keyVaultName: '${namePrefix}-kv-${uniqueString(guid)}'
-  workspaceName: '${namePrefix}-law-${uniqueString(guid)}'
-  managedIdentityName: '${namePrefix}-mi-${uniqueString(guid)}'
-  resourceGroupName: '${namePrefix}-rg-${uniqueString(guid)}'
-  storageAccountName: '${namePrefix}stg${uniqueString(guid)}'
-  containerRegistryName: '${namePrefix}acr${uniqueString(guid)}'
+  keyVaultName: '${namePrefix}-kv-${uniqueSuffix}'
+  workspaceName: '${namePrefix}-law-${uniqueSuffix}'
+  managedIdentityName: '${namePrefix}-mi-${uniqueSuffix}'
+  resourceGroupName: '${namePrefix}-rg-${uniqueSuffix}'
+  storageAccountName: '${namePrefix}stg${uniqueSuffix}'
+  containerRegistryName: '${namePrefix}acr${uniqueSuffix}'
 }
 
 // Resource Group


### PR DESCRIPTION
This PR updates the logic for the unique suffix used when naming resources deployed and applies the suffix to the display names of the two AAD app registration created. 

Addresses comment by fajterini https://github.com/Azure/ipam/issues/69#issuecomment-1384248970 and acknowledged by [DCMattyG](https://github.com/DCMattyG)

Added 
* Function `New-UniqueIPAMDeployString` 
* Variable `$unique` and `$uniqueSuffix` 

Removed
* Bicep param `guid`

Updated Flow 
- The deploy.ps1 script is started by the user 
- function `New-UniqueIPAMDeployString` called after initial setup and validation for the script occurs 
-- Function creates a unique 13 character string of numbers and lowercase letters and stores in `$unique`
-- `UIAppName` and `EngineAppName` values are updated 
-- The value of `$unique` is returned from the function
-  Function `Deploy-IPAMApplications` runs using the updated app name variables
- Variable `$unique` is passed into into function Deploy-Bicep as the value for `uniqueSuffix` 
- Bicep Templates use `uniqueSuffix` value to build string variables for resource names 

