### PR TITLE
Toggle User.ReadBasic.All permission

### DIFF
--- a/ui/src/features/admin/admin.js
+++ b/ui/src/features/admin/admin.js
@@ -319,7 +319,7 @@ export default function Administration() {
 
   const SearchUsers = React.useCallback((nameFilter) => {
     const request = {
-      scopes: ["Directory.Read.All"],
+      scopes: process.env.REACT_APP_USER_READBASIC_PERMISSION === "true" ? "User.ReadBasic.All" : "Directory.Read.All",
       account: accounts[0],
     };
 

--- a/ui/src/msal/authConfig.js
+++ b/ui/src/msal/authConfig.js
@@ -21,9 +21,11 @@ export const msalConfig = {
   },
 };
 
+const reqScope = process.env.REACT_APP_USER_READBASIC_PERMISSION === "true" ? "User.ReadBasic.All" : "Directory.Read.All"
+
 export const loginRequest = {
   scopes: [`api://${ENGINE_APP_ID}/access_as_user`],
-  extraScopesToConsent: ["openid", "profile", "offline_access", "User.Read", "Directory.Read.All"]
+  extraScopesToConsent: ["openid", "profile", "offline_access", "User.Read", reqScope]
 };
 
 export const apiRequest = {


### PR DESCRIPTION
Allow using the less intrusive User.ReadBasic.All permission instead of Directory.Read.All by setting the REACT_APP_USER_READBASIC_PERMISSION environment variable in the Web app.

All except the Admin tab under the admins blade works as usual. The Admin tab will trigger a reload once clicking the user search text field. I could look into disabling the tab as well if that would be a requirement.