### PR TITLE
PIP Upgrade Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /code
 COPY ./engine/requirements.txt /code/requirements.txt
 
 # Upgrade PIP
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip --progress-bar off
 
 # Install Dependencies
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt

--- a/engine/Dockerfile.deb
+++ b/engine/Dockerfile.deb
@@ -13,7 +13,7 @@ WORKDIR /ipam
 ADD ./requirements.txt .
 
 # Upgrade PIP
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip --progress-bar off
 
 # Install Dependencies
 RUN pip install --no-cache-dir --upgrade -r ./requirements.txt --progress-bar off

--- a/engine/Dockerfile.dev
+++ b/engine/Dockerfile.dev
@@ -9,7 +9,7 @@ ENV PORT=$PORT
 
 COPY ./requirements.txt /code/requirements.txt
 
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip --progress-bar off
 
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 

--- a/engine/Dockerfile.func
+++ b/engine/Dockerfile.func
@@ -9,7 +9,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 ADD ./requirements.txt .
 
 # Upgrade PIP
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip --progress-bar off
 
 # Install Dependencies
 RUN pip install --no-cache-dir --upgrade -r ./requirements.txt --progress-bar off

--- a/engine/Dockerfile.rhel
+++ b/engine/Dockerfile.rhel
@@ -16,7 +16,7 @@ USER root
 ADD ./requirements.txt /ipam
 
 # Upgrade PIP
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip --progress-bar off
 
 # Install Dependencies
 RUN pip install --no-cache-dir --upgrade -r ./requirements.txt --progress-bar off

--- a/engine/app/routers/space.py
+++ b/engine/app/routers/space.py
@@ -1134,7 +1134,7 @@ async def create_block_net(
     resv_cidrs = list(x['cidr'] for x in target_block['resv'] if not x['settledOn'])
     block_net_cidrs += resv_cidrs
 
-    ext_cidrs = list(x['cidr'] for x in target_block['externala'])
+    ext_cidrs = list(x['cidr'] for x in target_block['externals'])
     block_net_cidrs += ext_cidrs
 
     for v in target_block['vnets']:


### PR DESCRIPTION
-Added switch to hide progress bar during PIP upgrade process during Docker container build, which causes a failure on headless models such as Azure Container Registry builds
-Fixed small typo which was causing failures when associating a Virtual Network to a Block