### PR TITLE
Block Virtual Networks Fix

### DIFF
--- a/ui/src/features/configure/block/Utils/editVnets.jsx
+++ b/ui/src/features/configure/block/Utils/editVnets.jsx
@@ -586,6 +586,11 @@ export default function EditVnets(props) {
         refreshData();
       }
     }
+
+    if(!block) {
+      setVNets(null);
+      setSelectionModel(null);
+    }
   }, [block, subscriptions, prevBlock, refreshData]);
 
   return (


### PR DESCRIPTION
-Fixed issue when switching between Spaces/Blocks in the Configuration section where entering the Block Networks configuration will contain stale information from the previously selected Block and users must await a refresh for the data to update appropriately