### PR TITLE
Fix engine not starting up

### DIFF
--- a/engine/app/main.py
+++ b/engine/app/main.py
@@ -4,7 +4,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.exceptions import HTTPException as StarletteHTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from fastapi_restful.tasks import repeat_every
+from fastapi_utils.tasks import repeat_every
 from fastapi.encoders import jsonable_encoder
 
 from azure.identity.aio import ManagedIdentityCredential

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -1,6 +1,6 @@
 fastapi[all]>=0.103.0
 pydantic[email]>=2.3.0
-fastapi-restful[all]>=0.4.5
+fastapi-utils[all]>=0.7.0
 msal
 pyjwt
 cryptography


### PR DESCRIPTION
When deploying Azure/IPAM at our company we could not get it to work.
The uvicorn engine just sits there without listening to the port as specified.

The root cause is that uvicorn's `lifespan.on.startup` handlers never finish, because the `find_reservations` coroutine never does.

We traced this to a bug introduced in `fastapi_restful` 0.6.0. This commit switches to the `fastapi_utils` project (which the maintainer of `fastapi_restful` took over) where this issue is fixed in 0.7.0.

see https://github.com/dmontagu/fastapi-utils/pull/310