### PR TITLE
Remove unused parameter `disableUi` from example parameterfile

### DIFF
--- a/deploy/main.parameters.example.json
+++ b/deploy/main.parameters.example.json
@@ -28,9 +28,6 @@
     },
     "privateAcr": {
       "value": false
-    },
-    "disableUi": {
-      "value": false
     }
   }
 }


### PR DESCRIPTION
This parameter is not expected for the main.bicep file.