### PR TITLE
Introduce bicep param for acrImageTag

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -23,6 +23,9 @@ param deployAsFunc bool = false
 @description('Flag to Deploy IPAM as a Container')
 param deployAsContainer bool = false
 
+@description('IPAM Container Image Tag to use')
+param acrImageTag string = 'latest'
+
 @description('IPAM-UI App Registration Client/App ID')
 param uiAppId string = '00000000-0000-0000-0000-000000000000'
 
@@ -151,6 +154,7 @@ module appService './modules/appService.bicep' = if (!deployAsFunc) {
     managedIdentityClientId: managedIdentity.outputs.clientId
     workspaceId: logAnalyticsWorkspace.outputs.workspaceId
     deployAsContainer: deployAsContainer
+    acrImageTag: acrImageTag
     privateAcr: privateAcr
     privateAcrUri: privateAcr ? containerRegistry.outputs.acrUri : ''
   }
@@ -174,6 +178,7 @@ module functionApp './modules/functionApp.bicep' = if (deployAsFunc) {
     storageAccountName: resourceNames.storageAccountName
     workspaceId: logAnalyticsWorkspace.outputs.workspaceId
     deployAsContainer: deployAsContainer
+    acrImageTag: acrImageTag
     privateAcr: privateAcr
     privateAcrUri: privateAcr ? containerRegistry.outputs.acrUri : ''
   }

--- a/deploy/main.parameters.example.json
+++ b/deploy/main.parameters.example.json
@@ -26,6 +26,9 @@
     "deployAsContainer": {
       "value": false
     },
+    "acrImageTag": {
+      "value": "latest"
+    },
     "privateAcr": {
       "value": false
     },

--- a/deploy/modules/appService.bicep
+++ b/deploy/modules/appService.bicep
@@ -34,6 +34,9 @@ param workspaceId string
 @description('Flag to Deploy IPAM as a Container')
 param deployAsContainer bool = false
 
+@description('IPAM Container Image Tag to use')
+param acrImageTag string = 'latest'
+
 @description('Flag to Deploy Private Container Registry')
 param privateAcr bool
 
@@ -83,7 +86,7 @@ resource appService 'Microsoft.Web/sites@2021-02-01' = {
       acrUseManagedIdentityCreds: privateAcr ? true : false
       acrUserManagedIdentityID: privateAcr ? managedIdentityClientId : null
       alwaysOn: true
-      linuxFxVersion: deployAsContainer ? 'DOCKER|${acrUri}/ipam:latest' : 'PYTHON|${pythonVersion}'
+      linuxFxVersion: deployAsContainer ? 'DOCKER|${acrUri}/ipam:${acrImageTag}' : 'PYTHON|${pythonVersion}'
       appCommandLine: !deployAsContainer ? 'bash ./init.sh 8000' : null
       healthCheckPath: '/api/status'
       appSettings: concat(

--- a/deploy/modules/functionApp.bicep
+++ b/deploy/modules/functionApp.bicep
@@ -37,6 +37,9 @@ param workspaceId string
 @description('Flag to Deploy IPAM as a Container')
 param deployAsContainer bool = false
 
+@description('IPAM Container Image Tag to use')
+param acrImageTag string = 'latest'
+
 @description('Flag to Deploy Private Container Registry')
 param privateAcr bool
 
@@ -87,7 +90,7 @@ resource functionApp 'Microsoft.Web/sites@2021-03-01' = {
     siteConfig: {
       acrUseManagedIdentityCreds: privateAcr ? true : false
       acrUserManagedIdentityID: privateAcr ? managedIdentityClientId : null
-      linuxFxVersion: deployAsContainer ? 'DOCKER|${acrUri}/ipamfunc:latest' : 'PYTHON|${pythonVersion}'
+      linuxFxVersion: deployAsContainer ? 'DOCKER|${acrUri}/ipamfunc:${acrImageTag}' : 'PYTHON|${pythonVersion}'
       healthCheckPath: '/api/status'
       appSettings: concat(
         [


### PR DESCRIPTION
Currently when the repo is cloned and `git checkout v3.1.0` before deployment as container, the `latest` image will be used, not `3.1.0` as to be expected.
This PR will add support for the user to be explicit about what version of the image they want to deploy.

I've not added support for passing this parameter from `deploy.ps1`, only when using a parameter file.