### PR TITLE
Enable keyvault for template deployment

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -33,6 +33,9 @@ param engineAppId string
 @description('IPAM-Engine App Registration Client Secret')
 param engineAppSecret string
 
+@description('Additional identities to assign Key Vault Secrets User on the Key Vault')
+param additionalKeyVaultSecretsUserPrincipalIds string[] = []
+
 @description('Tags')
 param tags object = {}
 
@@ -90,6 +93,7 @@ module keyVault './modules/keyVault.bicep' = {
     keyVaultName: resourceNames.keyVaultName
     identityPrincipalId:  managedIdentity.outputs.principalId
     identityClientId:  managedIdentity.outputs.clientId
+    additionalKeyVaultSecretsUserPrincipalIds: additionalKeyVaultSecretsUserPrincipalIds
     uiAppId: uiAppId
     engineAppId: engineAppId
     engineAppSecret: engineAppSecret

--- a/deploy/modules/keyVault.bicep
+++ b/deploy/modules/keyVault.bicep
@@ -11,7 +11,7 @@ param identityPrincipalId string
 param identityClientId string
 
 @description('Additional identities to assign Key Vault Secrets User')
-param additionalKeyVaultSecretsUserPrincipalId string[] = []
+param additionalKeyVaultSecretsUserPrincipalIds string[] = []
 
 @description('AzureAD TenantId')
 param tenantId string = subscription().tenantId
@@ -121,7 +121,7 @@ resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
 
 var allKeyVaultSecretsUserPrincipalIds =  union(
   [identityPrincipalId],
-  additionalKeyVaultSecretsUserPrincipalId
+  additionalKeyVaultSecretsUserPrincipalIds
 )
 resource keyVaultUserAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [ for principalId in allKeyVaultSecretsUserPrincipalIds: {
   name: guid(keyVaultUser, principalId, keyVault.id)


### PR DESCRIPTION
DRAFT

Scenario:
- Deploy IPAM manually.
- Would like to schedule a deployment of the bicep in a nightly pipeline run to prevent drift.
- Would like the pipeline identity to be able to fetch the engineAppSecret during deployment, with the use of `az.getSecret()` function inside a .bicepparam.