### PR TITLE
Require only essential modules in deploy script

### DIFF
--- a/deploy/deploy.ps1
+++ b/deploy/deploy.ps1
@@ -5,9 +5,15 @@
 ###############################################################################################################
 
 # Set minimum version requirements
+# Az versions included in Az 11.6.0 (https://www.powershellgallery.com/packages/Az/11.6.0)
+# Graph versions included in Microsoft.Graph 2.19.0 (https://www.powershellgallery.com/packages/Microsoft.Graph/2.19.0)
 #Requires -Version 7.2
-#Requires -Modules @{ ModuleName="Az"; ModuleVersion="10.3.0"}
-#Requires -Modules @{ ModuleName="Microsoft.Graph"; ModuleVersion="2.0.0"}
+#Requires -Modules @{ ModuleName="Az.Accounts"; ModuleVersion="2.19.0"}
+#Requires -Modules @{ ModuleName="Az.Resources"; ModuleVersion="6.16.2"}
+#Requires -Modules @{ ModuleName="Az.Websites"; ModuleVersion="3.2.1"}
+#Requires -Modules @{ ModuleName="Az.Functions"; ModuleVersion="4.0.8"}
+#Requires -Modules @{ ModuleName="Microsoft.Graph.Authentication"; ModuleVersion="2.19.0"}
+#Requires -Modules @{ ModuleName="Microsoft.Graph.Identity.SignIns"; ModuleVersion="2.19.0"}
 
 # Intake and set global parameters
 [CmdletBinding(DefaultParameterSetName = 'AppContainer')]


### PR DESCRIPTION
### Description
It takes a long time to launch `deploy.ps1` in a fresh session (like from a pipeline). The require statements causes non-essential modules like Az.Sql and Microsoft.Graph.Groups to be loaded. Loading *every* Az and Graph module is very time-consuming.

### Runtime v3.3.0:
![image](https://github.com/Azure/ipam/assets/7443949/853e5022-dba5-4fe6-8928-557f2fe40400)

### Runtime during testing
Run deploy.ps1 in a clean shell environment without any requires-statements and run a Get-Module after to see what modules got loaded.
Or check what module contains each `-Az` or `-Mg` function individually:
```pwsh
$funcToCheck = 'Restart-AzWebApp'
Get-Module -ListAvailable | where {$_.ExportedCommands.Values.Name -contains $funcToCheck}
```

![image](https://github.com/Azure/ipam/assets/7443949/9d1a75c8-3bab-4dde-891e-a7aa85d4e87e)

