### PR TITLE
feat: add subresource integrity

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -29,7 +29,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" integrity="sha384-ybTqDDe2+DSPE9lYwR7gBoYDvOYOTuDp3HOOfvHfdvDSn6wNerIL6evSMvT5lNXl">
     <title>Azure IPAM</title>
   </head>
   <body>

--- a/ui/index.html
+++ b/ui/index.html
@@ -29,7 +29,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" integrity="sha384-ybTqDDe2+DSPE9lYwR7gBoYDvOYOTuDp3HOOfvHfdvDSn6wNerIL6evSMvT5lNXl">
     <title>Azure IPAM</title>
   </head>
   <body>


### PR DESCRIPTION
This fixes an unsafe implementation of a subresource.  Ref https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity

The hash has been properly generated, see below screenshots.

![image](https://github.com/user-attachments/assets/56e32e4d-ef06-475f-93dd-795b30b30fe8)
![image](https://github.com/user-attachments/assets/bdc5af21-8274-444d-8477-acd2b7fdfe7d)
