### PR TITLE
Fix Versioning Workflow for Azure IPAM v3.6.0

### DIFF
--- a/.github/workflows/azure-ipam-version.yml
+++ b/.github/workflows/azure-ipam-version.yml
@@ -60,7 +60,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.appToken.outputs.token }}
-          persist-credentials: false
 
       - name: Configure Git
         id: configureGit


### PR DESCRIPTION
-Allow token persistence so "git commit" will succeed

[version:3.6.0]