### PR TITLE
Enable soft delete for Key Vault

### DIFF
--- a/deploy/modules/keyVault.bicep
+++ b/deploy/modules/keyVault.bicep
@@ -34,7 +34,9 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   name: keyVaultName
   location: location
   properties: {
+    enableSoftDelete: true
     enablePurgeProtection: true
+    softDeleteRetentionInDays: 7
     enableRbacAuthorization: true
     tenantId: tenantId
     sku: {


### PR DESCRIPTION
Deployments fail if using the alz-bicep landing zone pattern when recommended azure key vault guard rails policy in effect.

https://www.azadvertizer.net/azpolicyadvertizer/1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d.html

Typical error:
```
     | 15:40:22 - The deployment 'ipamInfraDeploy-20260106033743PM' failed with error(s). Showing 1 out of 1 error(s). Status Message: The template deployment
     | failed because of policy violation. Please see details for more information. (Code: InvalidTemplateDeployment)  - Resource 'ipam-kv-bsuq3hb27vmuk' was
     | disallowed by policy. Policy identifiers: '[{"policyAssignment":{"name":"Enforce recommended guardrails for Azure Key
     | Vault","id":"/providers/Microsoft.Management/managementGroups/xxx/providers/Microsoft.Authorization/policyAssignments/Enforce-GR-KeyVault"},"policyDefinition":{"name":"Key vaults should have soft delete enabled","id":"/providers/Microsoft.Authorization/policyDefinitions/1e66c121-a66a-4b1f-9b83-0fd99bf0fc2d","version":"3.1.0"},"policySetDefinition":{"name":"Enforce recommended guardrails for Azure Key Vault","id":"/providers/Microsoft.Management/managementGroups/xxx/providers/Microsoft.Authorization/policySetDefinitions/Enforce-Guardrails-KeyVault","version":"1.0.0"}}]'. (Code:RequestDisallowedByPolicy) 
```

Suggested fix is to add the two parameters in keyVault.bicep

